### PR TITLE
interactive use cmd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,6 @@ jobs:
       - name: goreleaser-release
         if: startsWith(github.ref, 'refs/tags/v') ||  github.ref == 'refs/heads/main'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
           FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
         run: task goreleaser

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -80,7 +80,6 @@ brews:
     tap:
       owner: dpastoor 
       name: homebrew-tap 
-      token: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
     folder: Formula
     goarm: "7"
     test: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -80,7 +80,7 @@ brews:
     tap:
       owner: dpastoor 
       name: homebrew-tap 
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+      token: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
     folder: Formula
     goarm: "7"
     test: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -52,10 +52,8 @@ builds:
     goarch:
     - amd64
     - arm64
-    - arm
-  ignore:
-    - goos: darwin
-      goarch: '386'
+    goarm:
+    - "7"
 
 universal_binaries:
 - replace: true
@@ -83,6 +81,7 @@ brews:
       owner: dpastoor 
       name: homebrew-tap 
     folder: Formula
+    token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     goarm: "7"
     test: |
       system "#{bin}/qvm -v"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -80,8 +80,8 @@ brews:
     tap:
       owner: dpastoor 
       name: homebrew-tap 
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     folder: Formula
-    token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     goarm: "7"
     test: |
       system "#{bin}/qvm -v"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,6 +24,17 @@ release:
     sudo chmod +x /usr/local/bin/qvm
     ```
 
+    ### Linux User
+
+    Assumes `~/bin` is available in your PATH
+
+    ```
+    wget https://github.com/dpastoor/qvm/releases/download/{{ .Tag }}/qvm_Linux_x86_64.tar.gz -O /tmp/qvm.tar.gz
+    tar xzf /tmp/qvm.tar.gz qvm
+    mv qvm ~/bin/qvm
+    chmod +x ~/bin/qvm
+    ```
+
 before:
   hooks:
     - go mod tidy
@@ -40,10 +51,14 @@ builds:
       - linux
     goarch:
     - amd64
-    # - arm64
-    # - arm
-    # goarm:
-    # - "7"
+    - arm64
+    - arm
+  ignore:
+    - goos: darwin
+      goarch: '386'
+
+universal_binaries:
+- replace: true
 
 archives:
   - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'

--- a/README.md
+++ b/README.md
@@ -94,8 +94,6 @@ which ones are available remotely?
 
 ```
 qvm ls --remote
-qvm ls --remote --since 2022-05-01 # releases since 2022-05-01, follows YYYY-MM-DD
-qvm ls --remote -n 10 # latest 10 releases
 ```
 
 ### installing versions
@@ -111,8 +109,20 @@ running `qvm install`
 qvm install
 ```
 
-
-
+```
+qvm install
+? Which version do you want to install?  [Use arrows to move, type to filter]
+> v0.9.637
+  v0.9.636 - **installed**
+  v0.9.634
+  v0.9.633
+  v0.9.632
+  v0.9.629 - **installed**
+  v0.9.628
+  v0.9.626
+  v0.9.624
+  v0.9.622
+```
 
 ```shell
 qvm install $QUARTO_VERSION $ANOTHER_QUARTO_VERSION
@@ -134,15 +144,22 @@ qvm install latest
 qvm use $QUARTO_VERSION
 ```
 
-### using a version in a particular shell session
+To interactively select a version, run `qvm use`
 
-At any point can use a particular version in your shell session:
-
-```shell
-qvm use $QUARTO_VERSION --local
 ```
-
-
+qvm use
+? Which version do you want to use?  [Use arrows to move, type to filter]
+> v0.9.636
+  v0.9.629 - **active**
+  v0.9.587
+  v0.9.583
+  v0.9.565
+  v0.9.563
+  v0.9.562
+  v0.9.561
+  v0.9.559
+  v0.9.550
+```
 ### programmatic support utilities
 
 ```shell

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 
 	"github.com/dpastoor/qvm/internal/config"
@@ -36,10 +35,6 @@ func newLs(lsOpts lsOpts) error {
 			fmt.Printf("%s | %s | %s\n", r.GetTagName(), createdAt.Format("2006-01-02"), r.GetName())
 		}
 	} else {
-		activePath, err := filepath.EvalSymlinks(filepath.Join(config.GetPathToActiveBinDir(), "quarto"))
-		if err != nil && !errors.Is(err, os.ErrNotExist) {
-			return err
-		}
 		entries, err := os.ReadDir(config.GetPathToVersionsDir())
 		if errors.Is(err, os.ErrNotExist) {
 			fmt.Println("No installed quarto versions found")
@@ -61,11 +56,14 @@ func newLs(lsOpts lsOpts) error {
 		sort.Slice(entries, func(i, j int) bool {
 			return entries[i].Name() > entries[j].Name()
 		})
+		// no need to worry about errors since just need to know version
+		// for matching below and won't match if doesn't exist
+		activeVersion, _ := config.GetActiveVersion()
 		for _, e := range entries {
 			if e.IsDir() {
 				dinfo, _ := e.Info()
 				name := e.Name()
-				if filepath.Base(filepath.Dir(filepath.Dir(activePath))) == e.Name() {
+				if activeVersion == e.Name() {
 					name += " (active)"
 				} else {
 					name += "         "

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -33,24 +33,32 @@ func newUse(useOpts useOpts, version string) error {
 	if len(iv) == 0 {
 		return errors.New("no installed versions found, please install a version first")
 	}
+	if version == "latest" {
+		version = versions[0]
+	}
 	if version == "" {
-
-		err := survey.AskOne(&survey.Select{
-			Message: "Which version do you want to install?",
+		// not worried about an error here as an active version of
+		// empty string just won't match any description below
+		activeVersion, _ := config.GetActiveVersion()
+		err = survey.AskOne(&survey.Select{
+			Message: "Which version do you want to use?",
 			Options: versions,
-		}, &version)
+			Description: func(value string, index int) string {
+				if value == activeVersion {
+					return fmt.Sprintf("%s (active)", value)
+				}
+				return value
+			},
+		}, &version, survey.WithPageSize(10))
 		if err != nil {
 			return err
 		}
-	}
-	if version == "latest" {
-		version = versions[0]
 	}
 	quartopath, ok := iv[version]
 	if !ok {
 		return fmt.Errorf("version %s not found", version)
 	}
-	err = os.MkdirAll(config.GetPathToActiveBinDir(), 0700)
+	err = os.MkdirAll(config.GetPathToActiveBinDir(), 0755)
 	if err != nil {
 		return err
 	}
@@ -97,7 +105,11 @@ func newUseCmd() *useCmd {
 		RunE: func(_ *cobra.Command, args []string) error {
 			//TODO: Add your logic to gather config to pass code here
 			log.WithField("opts", fmt.Sprintf("%+v", root.opts)).Trace("use-opts")
-			if err := newUse(root.opts, args[0]); err != nil {
+			var version string
+			if len(args) > 0 {
+				version = args[0]
+			}
+			if err := newUse(root.opts, version); err != nil {
 				return err
 			}
 			return nil

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -45,9 +45,9 @@ func newUse(useOpts useOpts, version string) error {
 			Options: versions,
 			Description: func(value string, index int) string {
 				if value == activeVersion {
-					return fmt.Sprintf("%s (active)", value)
+					return "**active**"
 				}
-				return value
+				return ""
 			},
 		}, &version, survey.WithPageSize(10))
 		if err != nil {

--- a/internal/config/fs.go
+++ b/internal/config/fs.go
@@ -49,7 +49,7 @@ func GetPathToVersionsDir() string {
 func GetActiveVersion() (string, error) {
 	path, err := filepath.EvalSymlinks(GetPathToActiveQuartoExe())
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return "", errors.New("no active quarto version detected")
 		}
 		return "", err


### PR DESCRIPTION
This PR adds interactivity to `use` similar to `install`

In demo'ing with @kylebaron noticed just doing qvm use panic'd given how it was naively passing the 0th index of the args without a length check so also fixes that bug.

The new behavior looks like:

```
qvm use
? Which version do you want to use?  [Use arrows to move, type to filter]
> v0.9.636
  v0.9.629 - **active**
  v0.9.587
  v0.9.583
  v0.9.565
  v0.9.563
  v0.9.562
  v0.9.561
  v0.9.559
  v0.9.550
```